### PR TITLE
Added "IgnoreAttribute" configuration to ignore the attributes and only check node names

### DIFF
--- a/XmlUnit.xUnit/DiffConfiguration.cs
+++ b/XmlUnit.xUnit/DiffConfiguration.cs
@@ -8,6 +8,7 @@ namespace XmlUnit.Xunit
         public const string DEFAULT_DESCRIPTION = "XmlDiff";
         public const bool DEFAULT_USE_VALIDATING_PARSER = true;
         public const bool DEFAULT_IGNORE_ATTRIBUTE_ORDER = true;
+        public const bool DEFAULT_IGNORE_ATTRIBUTE = false;
 
         private readonly string _description;
         private readonly bool _useValidatingParser;
@@ -17,19 +18,22 @@ namespace XmlUnit.Xunit
         public DiffConfiguration(string description,
                                  bool useValidatingParser,
                                  WhitespaceHandling whitespaceHandling,
-                                 bool ignoreAttributeOrder)
+                                 bool ignoreAttributeOrder,
+                                 bool ignoreAttribute)
         {
             _description = description;
             _useValidatingParser = useValidatingParser;
             _whitespaceHandling = whitespaceHandling;
             this.ignoreAttributeOrder = ignoreAttributeOrder;
+            this.IgnoreAttribute = ignoreAttribute;
+
         }
 
         public DiffConfiguration(string description,
                                  bool useValidatingParser,
                                  WhitespaceHandling whitespaceHandling)
             : this(description, useValidatingParser, whitespaceHandling,
-                   DEFAULT_IGNORE_ATTRIBUTE_ORDER)
+                   DEFAULT_IGNORE_ATTRIBUTE_ORDER,DEFAULT_IGNORE_ATTRIBUTE)
         {
         }
 
@@ -88,5 +92,7 @@ namespace XmlUnit.Xunit
         {
             get { return ignoreAttributeOrder; }
         }
+
+        public bool IgnoreAttribute { get; set; }
     }
 }

--- a/XmlUnit.xUnit/Properties/AssemblyInfo.cs
+++ b/XmlUnit.xUnit/Properties/AssemblyInfo.cs
@@ -23,7 +23,7 @@ using System.Runtime.CompilerServices;
 // You can specify all values by your own or you can build default build and revision
 // numbers with the '*' character (the default):
 
-[assembly: AssemblyVersion("0.4.0.0")]
+[assembly: AssemblyVersion("0.4.1.0")]
 
 // The following attributes specify the key for the sign of your assembly. See the
 // .NET Framework documentation for more information about signing.

--- a/XmlUnit.xUnit/XmlDiff.cs
+++ b/XmlUnit.xUnit/XmlDiff.cs
@@ -208,51 +208,54 @@ namespace XmlUnit.Xunit
                                        XmlAttribute[] controlAttributes,
                                        XmlAttribute[] testAttributes)
         {
-            ArrayList unmatchedTestAttributes = new ArrayList();
-            unmatchedTestAttributes.AddRange(testAttributes);
-            for (int i = 0; i < controlAttributes.Length; ++i)
+            if (!_diffConfiguration.IgnoreAttribute)
             {
-                bool controlIsInNs = IsNamespaced(controlAttributes[i]);
-                string controlAttrName =
-                    GetUnNamespacedNodeName(controlAttributes[i]);
-                XmlAttribute testAttr = null;
-                if (!controlIsInNs)
+                ArrayList unmatchedTestAttributes = new ArrayList();
+                unmatchedTestAttributes.AddRange(testAttributes);
+                for (int i = 0; i < controlAttributes.Length; ++i)
                 {
-                    testAttr = FindAttributeByName(testAttributes,
-                                                   controlAttrName);
-                }
-                else
-                {
-                    testAttr = FindAttributeByNameAndNs(testAttributes,
-                                                        controlAttrName,
-                                                        controlAttributes[i]
-                                                            .NamespaceURI);
-                }
-
-                if (testAttr != null)
-                {
-                    unmatchedTestAttributes.Remove(testAttr);
-                    if (!_diffConfiguration.IgnoreAttributeOrder
-                        && testAttr != testAttributes[i])
+                    bool controlIsInNs = IsNamespaced(controlAttributes[i]);
+                    string controlAttrName =
+                        GetUnNamespacedNodeName(controlAttributes[i]);
+                    XmlAttribute testAttr = null;
+                    if (!controlIsInNs)
                     {
-                        DifferenceFound(DifferenceType.ATTR_SEQUENCE_ID,
+                        testAttr = FindAttributeByName(testAttributes,
+                                                       controlAttrName);
+                    }
+                    else
+                    {
+                        testAttr = FindAttributeByNameAndNs(testAttributes,
+                                                            controlAttrName,
+                                                            controlAttributes[i]
+                                                                .NamespaceURI);
+                    }
+
+                    if (testAttr != null)
+                    {
+                        unmatchedTestAttributes.Remove(testAttr);
+                        if (!_diffConfiguration.IgnoreAttributeOrder
+                            && testAttr != testAttributes[i])
+                        {
+                            DifferenceFound(DifferenceType.ATTR_SEQUENCE_ID,
+                                            result);
+                        }
+
+                        if (controlAttributes[i].Value != testAttr.Value)
+                        {
+                            DifferenceFound(DifferenceType.ATTR_VALUE_ID, result);
+                        }
+                    }
+                    else
+                    {
+                        DifferenceFound(DifferenceType.ATTR_NAME_NOT_FOUND_ID,
                                         result);
                     }
-
-                    if (controlAttributes[i].Value != testAttr.Value)
-                    {
-                        DifferenceFound(DifferenceType.ATTR_VALUE_ID, result);
-                    }
                 }
-                else
+                foreach (XmlAttribute a in unmatchedTestAttributes)
                 {
-                    DifferenceFound(DifferenceType.ATTR_NAME_NOT_FOUND_ID,
-                                    result);
+                    DifferenceFound(DifferenceType.ATTR_NAME_NOT_FOUND_ID, result);
                 }
-            }
-            foreach (XmlAttribute a in unmatchedTestAttributes)
-            {
-                DifferenceFound(DifferenceType.ATTR_NAME_NOT_FOUND_ID, result);
             }
         }
 

--- a/XmlUnit.xUnitTests/DiffConfigurationTests.cs
+++ b/XmlUnit.xUnitTests/DiffConfigurationTests.cs
@@ -12,6 +12,8 @@ namespace XmlUnit.XunitTests
         private const string xmlWithoutWhitespaceElement = "<elemA>as if<elemB/>\r\n</elemA>";
         private const string xmlWithWhitespaceElement = "<elemA>as if<elemB> </elemB></elemA>";
         private const string xmlWithoutWhitespace = "<elemA>as if<elemB/></elemA>";
+        private const string xmlIgnoringAttrbutesA = "<elem value='A'>text</elem>";
+        private const string xmlIgnoringAttrbutesB = "<elem value='B'>text</elem>";
 
         [Fact]
         public void DefaultConfiguredWithGenericDescription()
@@ -139,6 +141,22 @@ namespace XmlUnit.XunitTests
                              true, xmlUnitConfiguration);
             PerformAssertion(xmlWithoutWhitespaceElement, xmlWithWhitespaceElement,
                              true, xmlUnitConfiguration);
+        }
+
+        [Fact]
+        public void IgnoreAttributeIsFalseByDefault()
+        {
+            var xmlUnitConfiguration = new DiffConfiguration();
+            Assert.False(xmlUnitConfiguration.IgnoreAttribute);
+            
+        }
+
+        [Fact]
+        public void DiffWithIgnoringAttrbituesRetursEqualsIfHasSameNodesAndDifferentValues()
+        {
+            var xmlUnitConfiguration = new DiffConfiguration {IgnoreAttribute = true};
+            PerformAssertion(xmlIgnoringAttrbutesA, xmlIgnoringAttrbutesB,
+                            true, xmlUnitConfiguration);
         }
     }
 }


### PR DESCRIPTION
In my project i need to compare two xml files to check that files have the same nodes (in any order).
With the previous version of XmlUnit i couldn't check this. 

To solve this i added a new property in "DiffConfiguration.cs" call "IgnoreAttribute" (false by default).
In "XmlDiff.cs" the method "CompareAttributes" is ignored if the flag "IgnoreAttribute" is true.
